### PR TITLE
Big wire alert - use only nexogy.com domain

### DIFF
--- a/src/Nexogy/Mail/Transport/NexogyMailgunTransport.php
+++ b/src/Nexogy/Mail/Transport/NexogyMailgunTransport.php
@@ -19,6 +19,9 @@ class NexogyMailgunTransport extends \Illuminate\Mail\Transport\MailgunTransport
 		
 		$fromDomain = array_keys($message->getFrom())[0];
 		$fromDomain = substr($fromDomain, strrpos($fromDomain, '@') + 1);
+		if($fromDomain != 'rdsgi.com')
+			$fromDomain = 'nexogy.com';
+		
 		$this->setDomain($fromDomain);
 
 		$response = $client->post($this->url, ['auth' => ['api', $this->key],


### PR DESCRIPTION
When a CP send a quote from dna.nexogy.com we are selecting the wrong domain because of the from address. at least the from address is from rdsgi.com we need to use nexogy.com.

Long Live to the wires.